### PR TITLE
Added :escape filter for jade

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -158,6 +158,7 @@ BespokeGenerator.prototype.setupPackageJson = function setupPackageJson() {
       'grunt-concurrent': '~0.3.0',
       'grunt-gh-pages': '~0.6.0',
       'connect-livereload': '~0.2.0',
+      'html-strings': '0.0.1',
       'matchdep': '~0.3.0'
     },
     'engines': {

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -19,13 +19,7 @@ module.exports = function(grunt) {
           pretty: true,
           filters: {
             escape : function( block ) {
-              return block
-                  .replace( /&/g, '&amp;'  )
-                  .replace( /</g, '&lt;'   )
-                  .replace( />/g, '&gt;'   )
-                  .replace( /"/g, '&quot;' )
-                  .replace( /#/g, '&#35;'  )
-                  .replace( /\\/g, '\\\\'  );
+              return require('html-strings').escape(block);
             }
           }
         }

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -16,7 +16,18 @@ module.exports = function(grunt) {
           ext: '.html'
         }],
         options: {
-          pretty: true
+          pretty: true,
+          filters: {
+            escape : function( block ) {
+              return block
+                  .replace( /&/g, '&amp;'  )
+                  .replace( /</g, '&lt;'   )
+                  .replace( />/g, '&gt;'   )
+                  .replace( /"/g, '&quot;' )
+                  .replace( /#/g, '&#35;'  )
+                  .replace( /\\/g, '\\\\'  );
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
If you want to include HTML markup inside your presentation without pre escaping it you can now do :

          code.language-markup
            :escape
              <!doctype html>