### PR TITLE
Fix slide print styling (currently completely broken)

### DIFF
--- a/app/templates/src/styles/main.styl
+++ b/app/templates/src/styles/main.styl
@@ -78,9 +78,12 @@ article
     page-break-before: always
     position: static
     margin: 0
+    transition: none
 
 .bespoke-before
   transform: translateX(slide_transition_nudge_x * -1) translateX(slide_width / -2) rotateY(slide_transition_rotate_y * -1) translateX(slide_width / -2)
+  @media print
+    transform: none
 
 .bespoke-after
   transform: translateX(slide_transition_nudge_x) translateX(slide_width / 2) rotateY(slide_transition_rotate_y) translateX(slide_width / 2)


### PR DESCRIPTION
The print styling doesn't seem to currently work at all.

If you create a new project, and accept all the default options throughout, the resulting presentation works fine in normal browser usage, but prints only showing content for the first slide, and with blank pages for all subsequent slides.

This fixes that.
