### PR TITLE
Remove debowerify dependency and switch to the npm version of prismjs

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -174,7 +174,6 @@ BespokeGenerator.prototype.setupPackageJson = function setupPackageJson() {
     'dependencies': {},
     'devDependencies': {
       'bespoke': '^1.0.0',
-      'debowerify': '^0.7.1',
       'del': '^1.1.1',
       'gh-pages': '^0.2.0',
       'gulp': '^3.8.1',
@@ -190,7 +189,8 @@ BespokeGenerator.prototype.setupPackageJson = function setupPackageJson() {
       'gulp-util': '^2.2.17',
       'insert-css': '^0.2.0',
       'opn': '^0.1.2',
-      'through': '^2.3.4'
+      'through': '^2.3.4',
+      'prismjs': '^1.3.0'
     },
     'engines': {
       'node': '>=0.10.0'
@@ -205,6 +205,7 @@ BespokeGenerator.prototype.setupPackageJson = function setupPackageJson() {
     packageJson.devDependencies['normalizecss'] = '^3.0.0';
   }
 
+
   packageJson.devDependencies = sortedObject(packageJson.devDependencies);
   this.write('package.json', JSON.stringify(packageJson, null, 2));
 };
@@ -215,8 +216,6 @@ BespokeGenerator.prototype.setupBowerJson = function setupBowerJson() {
     'version': '0.0.0',
     'dependencies': {}
   };
-
-  if (this.syntax) bowerJson.dependencies['prism'] = 'gh-pages';
 
   this.write('bower.json', JSON.stringify(bowerJson, null, 2));
 };

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -6,7 +6,6 @@ var pkg = require('./package.json'),
   plumber = require('gulp-plumber'),
   rename = require('gulp-rename'),
   connect = require('gulp-connect'),
-  browserify = require('gulp-browserify'),
   uglify = require('gulp-uglify'),
   jade = require('gulp-jade'),
   stylus = require('gulp-stylus'),
@@ -23,7 +22,6 @@ var pkg = require('./package.json'),
 gulp.task('js', ['clean:js'], function() {
   return gulp.src('src/scripts/main.js')
     .pipe(isDist ? through() : plumber())
-    .pipe(browserify({ transform: ['debowerify'], debug: !isDist }))
     .pipe(isDist ? uglify() : through())
     .pipe(rename('build.js'))
     .pipe(gulp.dest('dist/build'))

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -6,6 +6,7 @@ var pkg = require('./package.json'),
   plumber = require('gulp-plumber'),
   rename = require('gulp-rename'),
   connect = require('gulp-connect'),
+  browserify = require('gulp-browserify'),
   uglify = require('gulp-uglify'),
   jade = require('gulp-jade'),
   stylus = require('gulp-stylus'),
@@ -22,6 +23,7 @@ var pkg = require('./package.json'),
 gulp.task('js', ['clean:js'], function() {
   return gulp.src('src/scripts/main.js')
     .pipe(isDist ? through() : plumber())
+    .pipe(browserify({ debug: !isDist }))
     .pipe(isDist ? uglify() : through())
     .pipe(rename('build.js'))
     .pipe(gulp.dest('dist/build'))

--- a/app/templates/src/scripts/main.js
+++ b/app/templates/src/scripts/main.js
@@ -10,7 +10,5 @@ bespoke.from('article', [<%= selectedPlugins.map(function(plugin) {
 ]);<% if (syntax) { %>
 
 // Prism syntax highlighting
-// This is actually loaded from "bower_components" thanks to
-// debowerify: https://github.com/eugeneware/debowerify
-require('prism');
+require('prismjs');
 <% } %>

--- a/app/templates/src/styles/main.styl
+++ b/app/templates/src/styles/main.styl
@@ -1,13 +1,13 @@
 // New to Stylus? Check out http://learnboost.github.io/stylus
 // Use modern CSS thanks to Autoprefixer: https://github.com/ai/autoprefixer
 
-<% if (syntax || !useTheme) { %>// Import CSS from "node_modules" and "bower_components"
+<% if (syntax || !useTheme) { %>// Import CSS from "node_modules"
 // thanks to Stylus' "import css" and "paths" options
 <% } %><% if (!useTheme) { %>
 @import 'normalizecss/normalize.css'
 <% } %><% if (syntax) { %>
-@import 'prism/themes/prism-okaidia.css'
-// Check out "bower_components/prism/themes/" for available themes
+@import 'prismjs/themes/prism-okaidia.css'
+// Check out "node_modules/prismjs/themes/" for available themes
 <% } %><% if (!useTheme) { %>
 // Style using Bespoke Classes: https://github.com/markdalgleish/bespoke-classes
 


### PR DESCRIPTION
This PR removes the dependency on debowerify, and switches prismjs to be the npm version (and also a much more recent version).