### PR TITLE
Override port

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -102,7 +102,7 @@ gulp.task('clean:images', function() {
 });
 
 gulp.task('connect', ['build'], function() {
-  connect.server({ root: 'dist', port: 8080, livereload: true });
+  connect.server({ root: 'dist', port: process.env.PORT || 8080, livereload: true });
 });
 
 gulp.task('watch', function() {


### PR DESCRIPTION
Allows e.g. `PORT=8081 gulp serve` if the user already has a different development server running.